### PR TITLE
Mode change button clarify design

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -69,6 +69,7 @@ class NavBar extends React.Component {
           className={classNames({
             'navbar__mode-btn': true,
             'navbar__mode-btn--active': mode === modeType,
+            'navbar__mode-btn--deactivated': mode === APP_MODES.STANDALONE ? [APP_MODES.CLIENT, APP_MODES.HOST_CLIENT].indexOf(modeType) != -1 : modeType === APP_MODES.STANDALONE
           })}
           onClick={this.props.changeAppMode(modeType)}
         >

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -69,7 +69,6 @@ class NavBar extends React.Component {
           className={classNames({
             'navbar__mode-btn': true,
             'navbar__mode-btn--active': mode === modeType,
-            'navbar__mode-btn--deactivated': mode === APP_MODES.STANDALONE ? [APP_MODES.CLIENT, APP_MODES.HOST_CLIENT].indexOf(modeType) != -1 : modeType === APP_MODES.STANDALONE
           })}
           onClick={this.props.changeAppMode(modeType)}
         >
@@ -81,9 +80,15 @@ class NavBar extends React.Component {
     return (
       <div className="navbar">
         <h1 className="navbar__title">Jude</h1>
-        {renderButton(APP_MODES.HOST_CLIENT)}
-        {renderButton(APP_MODES.CLIENT)}
-        {renderButton(APP_MODES.STANDALONE)}
+        <fieldset>
+          <legend>With Server</legend>
+          {renderButton(APP_MODES.HOST_CLIENT)}
+          {renderButton(APP_MODES.CLIENT)}
+        </fieldset>
+        <fieldset>
+          <legend>Without Server</legend>
+          {renderButton(APP_MODES.STANDALONE)}
+        </fieldset>
       </div>
     )
   }

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -81,12 +81,10 @@ class NavBar extends React.Component {
       <div className="navbar">
         <h1 className="navbar__title">Jude</h1>
         <fieldset>
-          <legend>With Server</legend>
           {renderButton(APP_MODES.HOST_CLIENT)}
           {renderButton(APP_MODES.CLIENT)}
         </fieldset>
         <fieldset>
-          <legend>Without Server</legend>
           {renderButton(APP_MODES.STANDALONE)}
         </fieldset>
       </div>

--- a/frontend/src/styles/components/_navbar.scss
+++ b/frontend/src/styles/components/_navbar.scss
@@ -50,8 +50,6 @@
 
     &--active {
       background-color: #fff;
-      border-color: #3caa63;
-      border-radius: 2px;
     }
   }
 }

--- a/frontend/src/styles/components/_navbar.scss
+++ b/frontend/src/styles/components/_navbar.scss
@@ -29,17 +29,28 @@
 
   &__mode-btn {
     float: right;
-    margin: 12px 0 0 0;
+    margin: 12px 3px 0 0;
     height: 34px;
     padding: 0 14px;
     color: #555555;
     background-color: #f9f9f9;
     border: 1px solid #e1e1e1;
+    outline: none;
+
+    &:last-of-type {
+      margin: 12px 10px 0 0;
+    }
 
     &--active {
       background-color: #fff;
-      border-color: #b5b5b5;
+      border-color: #3caa63;
+      border-radius: 2px;
     }
+
+    &--deactivated {
+      background-color: #dfdfdf;
+    }
+
   }
 }
 

--- a/frontend/src/styles/components/_navbar.scss
+++ b/frontend/src/styles/components/_navbar.scss
@@ -27,30 +27,32 @@
     }
   }
 
+  fieldset {
+    float: right;
+    display: inline-block;
+    margin-top: 5px;
+    padding: 5px;
+
+    legend {
+      font-size: 10px;
+    }
+  }
+
   &__mode-btn {
     float: right;
-    margin: 12px 3px 0 0;
+    margin: 0 3px 0 0;
     height: 34px;
     padding: 0 14px;
     color: #555555;
-    background-color: #f9f9f9;
+    background-color: #dfdfdf;
     border: 1px solid #e1e1e1;
     outline: none;
-
-    &:last-of-type {
-      margin: 12px 10px 0 0;
-    }
 
     &--active {
       background-color: #fff;
       border-color: #3caa63;
       border-radius: 2px;
     }
-
-    &--deactivated {
-      background-color: #dfdfdf;
-    }
-
   }
 }
 


### PR DESCRIPTION
Standalone / Server-using(host, host-client) 모드간의 구분을 보다 명확하게 할 수 있도록 
* 기존
  + <img width="307" alt="2017-01-09 3 14 07" src="https://cloud.githubusercontent.com/assets/3931792/21752351/bcc723d0-d619-11e6-9092-ed252aed8fe8.png">
  + <img width="320" alt="2017-01-09 3 14 10" src="https://cloud.githubusercontent.com/assets/3931792/21752353/bcc98b8e-d619-11e6-89c5-263ed8777c65.png">
  + <img width="305" alt="2017-01-09 3 14 13" src="https://cloud.githubusercontent.com/assets/3931792/21752352/bcc8e5ee-d619-11e6-8cc3-dda776de7feb.png">

* 변경
  + <img width="316" alt="2017-01-09 3 15 45" src="https://cloud.githubusercontent.com/assets/3931792/21752362/f3ebe742-d619-11e6-8f78-17d94af6e349.png">
  + <img width="315" alt="2017-01-09 3 15 49" src="https://cloud.githubusercontent.com/assets/3931792/21752363/f4e9c114-d619-11e6-872a-752c4100966c.png">
  + <img width="312" alt="2017-01-09 3 15 51" src="https://cloud.githubusercontent.com/assets/3931792/21752364/f6856618-d619-11e6-9d13-0a65cd10da9a.png">
:+1: